### PR TITLE
feat(negative record): bulk request endpoint & product-specific job detail mapping

### DIFF
--- a/internal/core/template/repository.go
+++ b/internal/core/template/repository.go
@@ -37,6 +37,8 @@ func (r *repository) GetAvailableTemplates() (map[string][]string, error) {
 		constant.TaxComplianceStatusTemplates,
 		constant.TaxScoreTemplates,
 		constant.TaxVerificationTemplates,
+		constant.RecycleNumberTemplates,
+		constant.NegativeRecordTemplates,
 		constant.GenRetailTemplates,
 	}
 

--- a/internal/core/template/service.go
+++ b/internal/core/template/service.go
@@ -90,6 +90,10 @@ func getTemplateDescription(product string) string {
 		return "Tax score template"
 	case constant.TaxVerificationTemplates:
 		return "Tax verification detail template"
+	case constant.RecycleNumberTemplates:
+		return "Recycle Number template"
+	case constant.NegativeRecordTemplates:
+		return "Negative record template"
 	case constant.GenRetailTemplates:
 		return "Gen Retail v3 template"
 	default:

--- a/internal/datahub/identity/negativerecord/controller..go
+++ b/internal/datahub/identity/negativerecord/controller..go
@@ -4,6 +4,7 @@ import (
 	"front-office/pkg/apperror"
 	"front-office/pkg/common/constant"
 	"front-office/pkg/helper"
+	"mime/multipart"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -18,6 +19,7 @@ type controller struct {
 
 type Controller interface {
 	SingleRequest(c *fiber.Ctx) error
+	BulkSearch(c *fiber.Ctx) error
 }
 
 func (ctrl *controller) SingleRequest(c *fiber.Ctx) error {
@@ -37,4 +39,25 @@ func (ctrl *controller) SingleRequest(c *fiber.Ctx) error {
 	}
 
 	return c.Status(result.StatusCode).JSON(result)
+}
+
+func (ctrl *controller) BulkSearch(c *fiber.Ctx) error {
+	file, ok := c.Locals(constant.ValidatedFile).(*multipart.FileHeader)
+	if !ok {
+		return apperror.BadRequest(constant.InvalidRequestFormat)
+	}
+
+	authCtx, err := helper.GetAuthContext(c)
+	if err != nil {
+		return apperror.Unauthorized(err.Error())
+	}
+
+	if err := ctrl.svc.BulkNegativeRecord(authCtx, file); err != nil {
+		return err
+	}
+
+	return c.Status(fiber.StatusOK).JSON(helper.SuccessResponse[any](
+		"success",
+		nil,
+	))
 }

--- a/internal/datahub/identity/negativerecord/init.go
+++ b/internal/datahub/identity/negativerecord/init.go
@@ -26,4 +26,5 @@ func SetupInit(apiGroup fiber.Router, cfg *application.Config, client httpclient
 
 	negativeRecordGroup := apiGroup.Group("negative-record")
 	negativeRecordGroup.Post("/single-request", middleware.GetJWTPayloadFromCookie(cfg), middleware.ValidateRequest(negativeRecordRequest{}), controller.SingleRequest)
+	negativeRecordGroup.Post("/bulk-request", middleware.GetJWTPayloadFromCookie(cfg), middleware.ValidateCSVFile(), controller.BulkSearch)
 }

--- a/internal/datahub/identity/negativerecord/service.go
+++ b/internal/datahub/identity/negativerecord/service.go
@@ -113,7 +113,7 @@ func (svc *service) NegativeRecord(authCtx *model.AuthContext, reqBody *negative
 }
 
 func (svc *service) BulkNegativeRecord(authCtx *model.AuthContext, file *multipart.FileHeader) error {
-	records, err := helper.ParseCSVFile(file, constant.CSVTemplateHeaderNagativeRecord)
+	records, err := helper.ParseCSVFile(file, constant.CSVTemplateHeaderNegativeRecord)
 	if err != nil {
 		return apperror.BadRequest(err.Error())
 	}

--- a/internal/datahub/identity/negativerecord/service.go
+++ b/internal/datahub/identity/negativerecord/service.go
@@ -9,10 +9,15 @@ import (
 	"front-office/pkg/common/constant"
 	"front-office/pkg/common/model"
 	"front-office/pkg/helper"
+	"mime/multipart"
 	"net/http"
+	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"github.com/usepzaka/validator"
 )
 
 func NewService(
@@ -43,6 +48,7 @@ type service struct {
 
 type Service interface {
 	NegativeRecord(authCtx *model.AuthContext, reqBody *negativeRecordRequest) (*model.ProCatAPIResponse[dataNegativeRecord], error)
+	BulkNegativeRecord(authCtx *model.AuthContext, fileHeader *multipart.FileHeader) error
 }
 
 func (svc *service) NegativeRecord(authCtx *model.AuthContext, reqBody *negativeRecordRequest) (*model.ProCatAPIResponse[dataNegativeRecord], error) {
@@ -106,10 +112,167 @@ func (svc *service) NegativeRecord(authCtx *model.AuthContext, reqBody *negative
 	return result, nil
 }
 
+func (svc *service) BulkNegativeRecord(authCtx *model.AuthContext, file *multipart.FileHeader) error {
+	records, err := helper.ParseCSVFile(file, constant.CSVTemplateHeaderNagativeRecord)
+	if err != nil {
+		return apperror.BadRequest(err.Error())
+	}
+
+	subscribedResp, err := svc.memberRepo.GetSubscribedProducts(authCtx.CompanyIdStr(), constant.SlugNegativeRecord)
+	if err != nil {
+		return apperror.MapRepoError(err, constant.ErrFetchSubscribedProduct)
+	}
+
+	subscribedIdStr := strconv.Itoa(int(subscribedResp.Data.SubsribedProductID))
+	quotaResp, err := svc.memberRepo.GetQuotaAPI(&member.QuotaParams{
+		MemberId:     authCtx.UserIdStr(),
+		CompanyId:    authCtx.CompanyIdStr(),
+		SubscribedId: subscribedIdStr,
+		QuotaType:    authCtx.QuotaTypeStr(),
+	})
+	if err != nil {
+		return apperror.MapRepoError(err, constant.FailedFetchQuota)
+	}
+
+	totalRequests := len(records) - 1
+	if authCtx.QuotaTypeStr() != "0" && quotaResp.Data.Quota < totalRequests {
+		return apperror.Forbidden(constant.ErrQuotaExceeded)
+	}
+
+	jobRes, err := svc.jobRepo.CreateJobAPI(&job.CreateJobRequest{
+		ProductId: subscribedResp.Data.ProductId,
+		MemberId:  authCtx.UserIdStr(),
+		CompanyId: authCtx.CompanyIdStr(),
+		Total:     totalRequests,
+	})
+	if err != nil {
+		return apperror.MapRepoError(err, constant.FailedCreateJob)
+	}
+	jobIdStr := helper.ConvertUintToString(jobRes.JobId)
+
+	var requests []*negativeRecordRequest
+	for i, rec := range records {
+		if i == 0 {
+			continue
+		}
+
+		requests = append(requests, &negativeRecordRequest{
+			CompanyName: rec[0],
+			LoanNo:      rec[1],
+		})
+	}
+
+	var (
+		wg         sync.WaitGroup
+		errChan    = make(chan error, len(requests))
+		batchCount = 0
+	)
+
+	for _, req := range requests {
+		wg.Add(1)
+
+		go func(negativeRecordReq *negativeRecordRequest) {
+			defer wg.Done()
+
+			if err := svc.processSingleNegativeRecord(&negativeRecordContext{
+				APIKey:         authCtx.APIKey,
+				JobIdStr:       jobIdStr,
+				MemberIdStr:    authCtx.UserIdStr(),
+				CompanyIdStr:   authCtx.CompanyIdStr(),
+				MemberId:       authCtx.UserId,
+				CompanyId:      authCtx.CompanyId,
+				ProductId:      subscribedResp.Data.ProductId,
+				ProductGroupId: subscribedResp.Data.Product.ProductGroupId,
+				JobId:          jobRes.JobId,
+				Request:        negativeRecordReq,
+			}); err != nil {
+				errChan <- err
+			}
+		}(req)
+
+		batchCount++
+		if batchCount == 100 {
+			time.Sleep(time.Second)
+			batchCount = 0
+		}
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	for err := range errChan {
+		log.Error().Err(err).Str("job_id", jobIdStr).Msg("error during bulk negative record processing")
+	}
+
+	if err := svc.jobService.FinalizeJob(jobIdStr); err != nil {
+		return err
+	}
+
+	if err := svc.operationRepo.AddLogOperation(&operation.AddLogRequest{
+		MemberId:  authCtx.UserId,
+		CompanyId: authCtx.CompanyId,
+		Action:    constant.EventNegativeRecordBulkReq,
+	}); err != nil {
+		log.Warn().
+			Err(err).
+			Str("action", constant.EventNegativeRecordBulkReq).
+			Msg(constant.MsgFailedAddOperationLog)
+	}
+
+	return nil
+}
+
+func (svc *service) processSingleNegativeRecord(params *negativeRecordContext) error {
+	trxId := helper.GenerateTrx(constant.TrxIdNegativeRecord)
+	if err := validator.ValidateStruct(params.Request); err != nil {
+		_ = svc.logFailedTransaction(params, trxId, err.Error(), http.StatusBadRequest)
+
+		return apperror.BadRequest(err.Error())
+	}
+
+	if err := svc.dummyLogTrans(params, trxId); err != nil {
+		return apperror.MapRepoError(err, constant.FailedCreateJob)
+	}
+
+	_, err := svc.repo.NegativeRecordAPI(params.APIKey, trxId, params.Request)
+	if err != nil {
+		_ = svc.logFailedTransaction(params, trxId, err.Error(), http.StatusBadGateway)
+		_ = svc.jobService.FinalizeFailedJob(params.JobIdStr)
+
+		return apperror.Internal("failed to process recycle number", err)
+	}
+
+	return nil
+}
+
+func (svc *service) logFailedTransaction(params *negativeRecordContext, trxId, msg string, status int) error {
+	return svc.transactionRepo.CreateLogTransAPI(&transaction.LogTransProCatRequest{
+		TransactionID:   trxId,
+		MemberID:        params.MemberId,
+		CompanyID:       params.CompanyId,
+		ProductID:       params.ProductId,
+		ProductGroupID:  params.ProductGroupId,
+		JobID:           params.JobId,
+		Message:         msg,
+		Status:          status,
+		PricingStrategy: "FREE",
+		Success:         false,
+		LoanNo:          params.Request.LoanNo,
+		ResponseBody: &transaction.ResponseBody{
+			Input:    params.Request,
+			DateTime: time.Now().Format(constant.FormatDateAndTime),
+		},
+		RequestBody:  params.Request,
+		RequestTime:  time.Now(),
+		ResponseTime: time.Now(),
+	})
+}
+
 // todo: remove
 func (svc *service) dummyLogTrans(params *negativeRecordContext, dummyTrxId string) error {
 	result := []dataNegativeRecordAPI{}
-	if params.Request.CompanyName == "artha" {
+	companyName := strings.TrimSpace(params.Request.CompanyName)
+	if strings.Contains(strings.ToLower(companyName), "artha") {
 		result = []dataNegativeRecordAPI{
 			{
 				CompanyName:         "KOPERASI SIMPAN PINJAM ARTHA MULIA",
@@ -156,6 +319,7 @@ func (svc *service) dummyLogTrans(params *negativeRecordContext, dummyTrxId stri
 			PricingStrategy: "FREE",
 			DateTime:        time.Now().Format(constant.FormatDateAndTime),
 		},
+		Data:         dataNegativeRecord{Result: result},
 		RequestBody:  params.Request,
 		RequestTime:  time.Now(),
 		ResponseTime: time.Now(),

--- a/internal/datahub/job/model.go
+++ b/internal/datahub/job/model.go
@@ -6,19 +6,20 @@ import (
 )
 
 type logTransProductCatalog struct {
-	MemberID               uint           `json:"member_id"`
-	CompanyID              uint           `json:"company_id"`
-	JobID                  uint           `json:"job_id"`
-	ProductID              uint           `json:"product_id"`
-	LoanNo                 string         `json:"loan_no"`
-	Status                 string         `json:"status"`
-	Message                *string        `json:"message"`
-	Input                  *logTransInput `json:"input"`
-	Data                   *logTransData  `json:"data"`
-	PricingStrategy        string         `json:"pricing_strategy"`
-	TransactionId          string         `json:"transaction_id"`
-	DateTime               string         `json:"datetime"`
-	RefTransProductCatalog any            `json:"ref_trans_product_catalog"`
+	MemberID               uint             `json:"member_id"`
+	CompanyID              uint             `json:"company_id"`
+	JobID                  uint             `json:"job_id"`
+	ProductID              uint             `json:"product_id"`
+	LoanNo                 string           `json:"loan_no"`
+	Status                 string           `json:"status"`
+	Message                *string          `json:"message"`
+	Input                  *logTransInput   `json:"input"`
+	RawData                any              `json:"data"`
+	Data                   logTransDataBase `json:"-"`
+	PricingStrategy        string           `json:"pricing_strategy"`
+	TransactionId          string           `json:"transaction_id"`
+	DateTime               string           `json:"datetime"`
+	RefTransProductCatalog any              `json:"ref_trans_product_catalog"`
 }
 
 type refTransProductCatalog struct {
@@ -55,6 +56,11 @@ type logTransInput struct {
 	NPWPOrNIK   *string `json:"npwp_or_nik,omitempty"`
 	LoanNo      string  `json:"loan_no,omitempty"`
 	CompanyName *string `json:"company_name,omitempty"`
+}
+
+type logTransDataNegativeRecord struct {
+	logTransData
+	Result []dataNegativeRecordAPI `json:"result"`
 }
 
 type jobListResponse struct {

--- a/internal/datahub/job/service.go
+++ b/internal/datahub/job/service.go
@@ -131,6 +131,14 @@ func (svc *service) GetJobDetails(filter *logFilter) (*model.AifcoreAPIResponse[
 		return nil, apperror.MapRepoError(err, "failed to fetch job detail")
 	}
 
+	if result.Data != nil {
+		for _, detail := range result.Data.JobDetails {
+			if err := remapLogTransData(filter.ProductSlug, detail); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	return result, nil
 }
 
@@ -138,6 +146,14 @@ func (svc *service) GetJobDetailsByDateRange(filter *logFilter) (*model.AifcoreA
 	result, err := svc.repo.GetJobsSummaryAPI(filter)
 	if err != nil {
 		return nil, apperror.MapRepoError(err, "failed to fetch job detail")
+	}
+
+	if result.Data != nil {
+		for _, detail := range result.Data.JobDetails {
+			if err := remapLogTransData(filter.ProductSlug, detail); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return result, nil
@@ -161,6 +177,14 @@ func (svc *service) exportJobDetailsToCSV(
 	resp, err := fetchFunc(filter)
 	if err != nil {
 		return "", apperror.MapRepoError(err, "failed to fetch job details")
+	}
+
+	if resp.Data != nil {
+		for _, detail := range resp.Data.JobDetails {
+			if err := remapLogTransData(filter.ProductSlug, detail); err != nil {
+				return "", apperror.Internal("failed to remap job detail data", err)
+			}
+		}
 	}
 
 	cfg, ok := exportProductMap[filter.ProductSlug]
@@ -437,8 +461,12 @@ func mapLoanRecordCheckerRow(isMasked bool, d *logTransProductCatalog) []string 
 	}
 
 	if d.Data != nil {
-		remarks = *d.Data.Remarks
-		status = *d.Data.Status
+		if d.Data.GetRemarks() != nil {
+			remarks = *d.Data.GetRemarks()
+		}
+		if d.Data.GetStatus() != nil {
+			status = *d.Data.GetStatus()
+		}
 	}
 
 	var ref refTransProductCatalog
@@ -479,7 +507,10 @@ func mapMultipleLoanRow(isMasked bool, d *logTransProductCatalog) []string {
 	}
 
 	if d.Data != nil {
-		queryCount = *d.Data.QueryCount
+		if d.Data.GetQueryCount() != nil {
+			queryCount = *d.Data.GetQueryCount()
+		}
+
 	}
 
 	var ref refTransProductCatalog
@@ -507,7 +538,7 @@ func mapMultipleLoanRow(isMasked bool, d *logTransProductCatalog) []string {
 
 func mapTaxComplianceRow(isMasked bool, d *logTransProductCatalog) []string {
 	var (
-		description, nama, address, status, npwp string
+		description, name, address, status, npwp string
 	)
 
 	if d.Message != nil {
@@ -515,9 +546,15 @@ func mapTaxComplianceRow(isMasked bool, d *logTransProductCatalog) []string {
 	}
 
 	if d.Data != nil {
-		nama = *d.Data.Nama
-		address = *d.Data.Alamat
-		status = *d.Data.Status
+		if d.Data.GetName() != nil {
+			name = *d.Data.GetName()
+		}
+		if d.Data.GetStatus() != nil {
+			status = *d.Data.GetStatus()
+		}
+		if d.Data.GetAddress() != nil {
+			address = *d.Data.GetAddress()
+		}
 	}
 
 	var ref refTransProductCatalog
@@ -534,7 +571,7 @@ func mapTaxComplianceRow(isMasked bool, d *logTransProductCatalog) []string {
 	return []string{
 		// d.Input.LoanNo,
 		npwp,
-		nama,
+		name,
 		address,
 		status,
 		d.Status,
@@ -552,10 +589,18 @@ func mapTaxScoreRow(isMasked bool, d *logTransProductCatalog) []string {
 	}
 
 	if d.Data != nil {
-		name = *d.Data.Nama
-		address = *d.Data.Alamat
-		status = *d.Data.Status
-		score = *d.Data.Score
+		if d.Data.GetName() != nil {
+			name = *d.Data.GetName()
+		}
+		if d.Data.GetStatus() != nil {
+			status = *d.Data.GetStatus()
+		}
+		if d.Data.GetAddress() != nil {
+			address = *d.Data.GetAddress()
+		}
+		if d.Data.GetScore() != nil {
+			score = *d.Data.GetScore()
+		}
 	}
 
 	var ref refTransProductCatalog
@@ -591,12 +636,23 @@ func mapTaxVerificationRow(isMasked bool, d *logTransProductCatalog) []string {
 	}
 
 	if d.Data != nil {
-		name = *d.Data.Nama
-		address = *d.Data.Alamat
-		npwpVerification = *d.Data.NPWPVerification
 		// npwp = *d.Data.NPWP
-		status = *d.Data.Status
-		taxCompliance = *d.Data.TaxCompliance
+
+		if d.Data.GetName() != nil {
+			name = *d.Data.GetName()
+		}
+		if d.Data.GetStatus() != nil {
+			status = *d.Data.GetStatus()
+		}
+		if d.Data.GetAddress() != nil {
+			address = *d.Data.GetAddress()
+		}
+		if d.Data.GetNPWPVerification() != nil {
+			npwpVerification = *d.Data.GetNPWPVerification()
+		}
+		if d.Data.GetTaxCompliance() != nil {
+			taxCompliance = *d.Data.GetTaxCompliance()
+		}
 	}
 
 	var ref refTransProductCatalog
@@ -638,9 +694,15 @@ func mapNPWPVerificationRow(isMasked bool, d *logTransProductCatalog) []string {
 	}
 
 	if d.Data != nil {
-		name = *d.Data.Nama
-		address = *d.Data.Alamat
-		status = *d.Data.Status
+		if d.Data.GetName() != nil {
+			name = *d.Data.GetName()
+		}
+		if d.Data.GetStatus() != nil {
+			status = *d.Data.GetStatus()
+		}
+		if d.Data.GetAddress() != nil {
+			address = *d.Data.GetAddress()
+		}
 	}
 
 	var ref refTransProductCatalog
@@ -677,7 +739,9 @@ func mapRecycleNumberRow(isMasked bool, d *logTransProductCatalog) []string {
 	}
 
 	if d.Data != nil {
-		status = *d.Data.Status
+		if d.Data.GetStatus() != nil {
+			status = *d.Data.GetStatus()
+		}
 	}
 
 	var ref refTransProductCatalog
@@ -713,7 +777,9 @@ func mapPhoneNIKRow(isMasked bool, d *logTransProductCatalog) []string {
 	}
 
 	if d.Data != nil {
-		status = *d.Data.Status
+		if d.Data.GetStatus() != nil {
+			status = *d.Data.GetStatus()
+		}
 	}
 
 	var ref refTransProductCatalog
@@ -759,4 +825,57 @@ func mapToClientResponse(src *model.AifcoreAPIResponse[*jobListResponse]) *jobLi
 		Jobs:      jobs,
 		TotalData: src.Data.TotalData,
 	}
+}
+
+type logTransDataBase interface {
+	GetRemarks() *string
+	GetStatus() *string
+	GetQueryCount() *int
+	GetName() *string
+	GetScore() *string
+	GetAddress() *string
+	GetNPWP() *string
+	GetNPWPVerification() *string
+	GetTaxCompliance() *string
+}
+
+func (d *logTransData) GetRemarks() *string          { return d.Remarks }
+func (d *logTransData) GetStatus() *string           { return d.Status }
+func (d *logTransData) GetQueryCount() *int          { return d.QueryCount }
+func (d *logTransData) GetName() *string             { return d.Nama }
+func (d *logTransData) GetScore() *string            { return d.Score }
+func (d *logTransData) GetAddress() *string          { return d.Alamat }
+func (d *logTransData) GetNPWP() *string             { return d.NPWP }
+func (d *logTransData) GetNPWPVerification() *string { return d.NPWPVerification }
+func (d *logTransData) GetTaxCompliance() *string    { return d.TaxCompliance }
+
+func remapLogTransData(productSlug string, detail *logTransProductCatalog) error {
+	if detail.RawData == nil {
+		return nil
+	}
+
+	raw, err := json.Marshal(detail.RawData)
+	if err != nil {
+		return err
+	}
+
+	switch productSlug {
+	case constant.SlugNegativeRecord:
+		var data logTransDataNegativeRecord
+		if err := json.Unmarshal(raw, &data); err != nil {
+			return err
+		}
+
+		detail.Data = &data
+
+	default:
+		var data logTransData
+		if err := json.Unmarshal(raw, &data); err != nil {
+			return err
+		}
+
+		detail.Data = &data
+	}
+
+	return nil
 }

--- a/pkg/common/constant/csvheader.go
+++ b/pkg/common/constant/csvheader.go
@@ -87,6 +87,11 @@ var CSVTemplateHeaderRecycleNumber = []string{
 	CSVHeaderLoanNumber,
 }
 
+var CSVTemplateHeaderNegativeRecord = []string{
+	CSVHeaderCompanyName,
+	CSVHeaderLoanNumber,
+}
+
 // CSV Export Header
 
 var CSVExportHeaderPhoneLive = []string{

--- a/pkg/common/constant/paths.go
+++ b/pkg/common/constant/paths.go
@@ -7,6 +7,7 @@ const (
 	PhoneLiveTemplates           = "phonelivestatus"
 	PhoneNIKMatchingTemplates    = "phonenikmatching"
 	RecycleNumberTemplates       = "recyclenumber"
+	NegativeRecordTemplates      = "negativerecord"
 	LoanRecordCheckerTemplates   = "loanrecordchecker"
 	MultipleLoanTemplates        = "multipleloan"
 	NPWPVerificationTemplates    = "npwpverification"

--- a/pkg/common/constant/product.go
+++ b/pkg/common/constant/product.go
@@ -7,7 +7,6 @@ const (
 	SlugPhoneNIKMatching = "IDENTITY_phone_to_nik"
 	SlugRecycleNumber    = "IDENTITY_recycle_number"
 	SlugNPWPVerification = "IDENTITY_npwp_verification"
-	SlugNegativeRecord   = "IDENTITY_negative_record"
 
 	SlugLoanRecordChecker  = "COMPLIANCE_loan_record_checker"
 	Slug7DaysMultipleLoan  = "COMPLIANCE_7d_multiple_loan"
@@ -17,6 +16,8 @@ const (
 	SlugTaxComplianceStatus   = "INCOMETAX_tax_compliance_status"
 	SlugTaxScore              = "INCOMETAX_tax_score"
 	SlugTaxVerificationDetail = "INCOMETAX_tax_verification_detail"
+
+	SlugNegativeRecord = "COMPLIT_negative_record"
 
 	SlugCustomMAW2 = "CUSTOM_maw2"
 )

--- a/public/templates/negativerecord/template-v1.0.0.csv
+++ b/public/templates/negativerecord/template-v1.0.0.csv
@@ -1,0 +1,2 @@
+Company Name,Loan Number
+Artha,123


### PR DESCRIPTION
## Summary
Adds bulk request functionality for the Negative Record product and refactors job detail response handling to support product-specific data mapping.

## Changes

### Negative Record – Bulk Request
- Add endpoint for negative record bulk request
- Add CSV template for bulk request input

### Job Detail Response Refactor
- Introduce `logTransDataBase` interface for product-aware data unmarshaling
- Add `logTransDataNegativeRecord` struct to carry `result` field specific to negative record
- Remap `data` field to the appropriate concrete type based on `product_slug` after fetching from upstream API (applied to `GetJobDetails`, `GetJobDetailsByDateRange`, and `ExportJobDetails`)